### PR TITLE
Webview improvements/fixes

### DIFF
--- a/src/WinBlur.App/FeedPage.xaml
+++ b/src/WinBlur.App/FeedPage.xaml
@@ -383,6 +383,22 @@
                           Icon="World"
                           Label="Open in browser"
                           Click="openInBrowserButton_Click" />
+            <AppBarButton x:Name="previousArticleButton"
+                          Label="Previous"
+                          IsEnabled="{x:Bind CanNavigateBack(articleDetailView.SelectedIndex), Mode=OneWay}"
+                          Click="previousArticleButton_Click">
+                <AppBarButton.Icon>
+                    <FontIcon Glyph="&#xE00E;"/>
+                </AppBarButton.Icon>
+            </AppBarButton>
+            <AppBarButton x:Name="nextArticleButton"
+                          Label="Next"
+                          IsEnabled="{x:Bind CanNavigateForward(articleDetailView.SelectedIndex), Mode=OneWay}"
+                          Click="nextArticleButton_Click">
+                <AppBarButton.Icon>
+                    <FontIcon Glyph="&#xE00F;"/>
+                </AppBarButton.Icon>
+            </AppBarButton>
 
             <CommandBar.SecondaryCommands>
                 <AppBarButton x:Name="starButton"

--- a/src/WinBlur.App/FeedPage.xaml
+++ b/src/WinBlur.App/FeedPage.xaml
@@ -273,6 +273,8 @@
             <FlipView.ItemTemplate>
                 <DataTemplate x:DataType="model:Article">
                         <WebView2 x:Name="articleTextView"
+                                  CanGoBack="False"
+                                  CanGoForward="False"
                                   helpers:DependencyPropertyHelper.HtmlString="{x:Bind ViewContent, Mode=OneWay}"
                                   helpers:DependencyPropertyHelper.HtmlContentBackground="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"
                                   helpers:DependencyPropertyHelper.HtmlContentForeground="{ThemeResource TextFillColorPrimaryBrush}"

--- a/src/WinBlur.App/FeedPage.xaml
+++ b/src/WinBlur.App/FeedPage.xaml
@@ -8,6 +8,7 @@
       xmlns:model="using:WinBlur.App.Model"
       xmlns:vmodel="using:WinBlur.App.ViewModel"
       xmlns:helpers="using:WinBlur.App.Helpers"
+      xmlns:view="using:WinBlur.App.View"
       mc:Ignorable="d">
 
     <Page.Resources>
@@ -269,12 +270,17 @@
                        Visibility="{x:Bind viewModel.NoArticles, Mode=OneWay}" />
         </StackPanel>
 
-        <FlipView x:Name="articleDetailView" Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}" Grid.Row="1" Grid.Column="1">
+        <view:ArticleFlipView x:Name="articleDetailView"
+                              Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"
+                              Style="{StaticResource ArticleFlipViewStyle}"
+                              Grid.Row="1"
+                              Grid.Column="1">
             <FlipView.ItemTemplate>
                 <DataTemplate x:DataType="model:Article">
                         <WebView2 x:Name="articleTextView"
                                   CanGoBack="False"
                                   CanGoForward="False"
+                                  DefaultBackgroundColor="{ThemeResource SolidBackgroundFillColorSecondary}"
                                   helpers:DependencyPropertyHelper.HtmlString="{x:Bind ViewContent, Mode=OneWay}"
                                   helpers:DependencyPropertyHelper.HtmlContentBackground="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"
                                   helpers:DependencyPropertyHelper.HtmlContentForeground="{ThemeResource TextFillColorPrimaryBrush}"
@@ -286,7 +292,7 @@
                                   VerticalAlignment="Stretch" />
                 </DataTemplate>
             </FlipView.ItemTemplate>
-        </FlipView>
+        </view:ArticleFlipView>
 
         <ProgressBar x:Name="ArticleTextViewLoadingProgress"
                      Grid.Row="1"
@@ -383,22 +389,6 @@
                           Icon="World"
                           Label="Open in browser"
                           Click="openInBrowserButton_Click" />
-            <AppBarButton x:Name="previousArticleButton"
-                          Label="Previous"
-                          IsEnabled="{x:Bind CanNavigateBack(articleDetailView.SelectedIndex), Mode=OneWay}"
-                          Click="previousArticleButton_Click">
-                <AppBarButton.Icon>
-                    <FontIcon Glyph="&#xE00E;"/>
-                </AppBarButton.Icon>
-            </AppBarButton>
-            <AppBarButton x:Name="nextArticleButton"
-                          Label="Next"
-                          IsEnabled="{x:Bind CanNavigateForward(articleDetailView.SelectedIndex), Mode=OneWay}"
-                          Click="nextArticleButton_Click">
-                <AppBarButton.Icon>
-                    <FontIcon Glyph="&#xE00F;"/>
-                </AppBarButton.Icon>
-            </AppBarButton>
 
             <CommandBar.SecondaryCommands>
                 <AppBarButton x:Name="starButton"

--- a/src/WinBlur.App/FeedPage.xaml
+++ b/src/WinBlur.App/FeedPage.xaml
@@ -271,7 +271,6 @@
         </StackPanel>
 
         <view:ArticleFlipView x:Name="articleDetailView"
-                              Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"
                               Style="{StaticResource ArticleFlipViewStyle}"
                               Grid.Row="1"
                               Grid.Column="1">
@@ -280,16 +279,21 @@
                         <WebView2 x:Name="articleTextView"
                                   CanGoBack="False"
                                   CanGoForward="False"
-                                  DefaultBackgroundColor="{ThemeResource SolidBackgroundFillColorSecondary}"
+                                  DefaultBackgroundColor="Transparent"
                                   helpers:DependencyPropertyHelper.HtmlString="{x:Bind ViewContent, Mode=OneWay}"
                                   helpers:DependencyPropertyHelper.HtmlContentBackground="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"
                                   helpers:DependencyPropertyHelper.HtmlContentForeground="{ThemeResource TextFillColorPrimaryBrush}"
                                   helpers:DependencyPropertyHelper.HtmlContentLinkColor="{ThemeResource ArticleContentHyperlinkBrush}"
+                                  helpers:DependencyPropertyHelper.HtmlContentScrollbarBackgroundColor="{ThemeResource ArticleContentScrollbarBackgroundBrush}"
                                   helpers:DependencyPropertyHelper.HtmlContentScrollbarColor="{ThemeResource ArticleContentScrollbarBrush}"
                                   Loaded="articleTextView_Loaded"
                                   NavigationStarting="articleTextView_NavigationStarting"
                                   HorizontalAlignment="Stretch"
-                                  VerticalAlignment="Stretch" />
+                                  VerticalAlignment="Stretch">
+                            <WebView2.Resources>
+                                <SolidColorBrush x:Name="BrushForThemeBackgroundColor" Color="{ThemeResource LayerFillColorDefault}"/>
+                            </WebView2.Resources>
+                        </WebView2>
                 </DataTemplate>
             </FlipView.ItemTemplate>
         </view:ArticleFlipView>
@@ -350,14 +354,11 @@
                        Opacity="0.75" />
         </StackPanel>
 
-        <Border Grid.Row="0" Grid.Column="1" Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}" BorderBrush="{ThemeResource CardStrokeColorDefault}" BorderThickness="0,1,0,0"/>
-
         <CommandBar x:Name="articleCommandBar"
                     Grid.Row="0"
                     Grid.Column="1"
                     DefaultLabelPosition="Right"
                     VerticalContentAlignment="Top"
-                    Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"
                     Visibility="{x:Bind viewModel.SelectedArticle, Converter={StaticResource NullToCollapsedConverter}, Mode=OneWay}">
             <AppBarElementContainer>
                 <SplitButton x:Name="readingModeSplitButton" Style="{StaticResource SplitButtonCommandBarStyle}" Click="readingModeSplitButton_Click">

--- a/src/WinBlur.App/FeedPage.xaml.cs
+++ b/src/WinBlur.App/FeedPage.xaml.cs
@@ -367,7 +367,7 @@ namespace WinBlur.App
             var settings = webView.CoreWebView2.Settings;
             settings.AreBrowserAcceleratorKeysEnabled = false;
             settings.AreDefaultScriptDialogsEnabled = false;
-            settings.AreDevToolsEnabled = false;
+            settings.AreDevToolsEnabled = App.TestModeHelper.TestMode;
             settings.AreHostObjectsAllowed = false;
             settings.IsBuiltInErrorPageEnabled = false;
             settings.IsGeneralAutofillEnabled = false;

--- a/src/WinBlur.App/FeedPage.xaml.cs
+++ b/src/WinBlur.App/FeedPage.xaml.cs
@@ -294,22 +294,20 @@ namespace WinBlur.App
                 }
             }
         }
-
-        private IconElement GetCommentsIcon(Article a)
+        private void previousArticleButton_Click(object sender, RoutedEventArgs e)
         {
-            return new FontIcon
+            if (articleDetailView.SelectedIndex != 0)
             {
-                FontSize = 20,
-                Glyph = a == null || a.ShareCount == 0 ?
-                    Converters.IconGlyphToString(Converters.IconGlyph.CommentsEmpty) :
-                    Converters.IconGlyphToString(Converters.IconGlyph.CommentsFull),
-            };
+                articleDetailView.SelectedIndex--;
+            }
         }
 
-        private string GetCommentsLabel(Article a)
+        private void nextArticleButton_Click(object sender, RoutedEventArgs e)
         {
-            if (a == null) return "Show shares";
-            return a.ShareCount == 1 ? string.Format("Show {0} share", a.ShareCount) : string.Format("Show {0} shares", a.ShareCount);
+            if (articleDetailView.SelectedIndex != (articleDetailView.Items.Count - 1))
+            {
+                articleDetailView.SelectedIndex++;
+            }
         }
 
         private void starButton_Click(object sender, RoutedEventArgs e)
@@ -1119,6 +1117,20 @@ namespace WinBlur.App
 
             // Reload comments so hopefully the PersonPicture controls work properly
             LoadComments(viewModel.SelectedArticle);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private bool CanNavigateBack(int selectedIndex)
+        {
+            return selectedIndex != 0;
+        }
+
+        private bool CanNavigateForward(int selectedIndex)
+        {
+            return selectedIndex != (articleDetailView?.Items.Count - 1);
         }
 
         #endregion

--- a/src/WinBlur.App/FeedPage.xaml.cs
+++ b/src/WinBlur.App/FeedPage.xaml.cs
@@ -294,21 +294,6 @@ namespace WinBlur.App
                 }
             }
         }
-        private void previousArticleButton_Click(object sender, RoutedEventArgs e)
-        {
-            if (articleDetailView.SelectedIndex != 0)
-            {
-                articleDetailView.SelectedIndex--;
-            }
-        }
-
-        private void nextArticleButton_Click(object sender, RoutedEventArgs e)
-        {
-            if (articleDetailView.SelectedIndex != (articleDetailView.Items.Count - 1))
-            {
-                articleDetailView.SelectedIndex++;
-            }
-        }
 
         private void starButton_Click(object sender, RoutedEventArgs e)
         {
@@ -1117,20 +1102,6 @@ namespace WinBlur.App
 
             // Reload comments so hopefully the PersonPicture controls work properly
             LoadComments(viewModel.SelectedArticle);
-        }
-
-        #endregion
-
-        #region Helpers
-
-        private bool CanNavigateBack(int selectedIndex)
-        {
-            return selectedIndex != 0;
-        }
-
-        private bool CanNavigateForward(int selectedIndex)
-        {
-            return selectedIndex != (articleDetailView?.Items.Count - 1);
         }
 
         #endregion

--- a/src/WinBlur.App/FeedPage.xaml.cs
+++ b/src/WinBlur.App/FeedPage.xaml.cs
@@ -380,6 +380,16 @@ namespace WinBlur.App
         {
             var webView = (WebView2)sender;
             await webView.EnsureCoreWebView2Async();
+
+            var settings = webView.CoreWebView2.Settings;
+            settings.AreBrowserAcceleratorKeysEnabled = false;
+            settings.AreDefaultScriptDialogsEnabled = false;
+            settings.AreDevToolsEnabled = false;
+            settings.AreHostObjectsAllowed = false;
+            settings.IsBuiltInErrorPageEnabled = false;
+            settings.IsGeneralAutofillEnabled = false;
+            settings.IsSwipeNavigationEnabled = false;
+            settings.IsWebMessageEnabled = false;
         }
 
         private async void articleTextView_NavigationStarting(WebView2 sender, CoreWebView2NavigationStartingEventArgs args)

--- a/src/WinBlur.App/Helpers/DependencyPropertyHelper.cs
+++ b/src/WinBlur.App/Helpers/DependencyPropertyHelper.cs
@@ -71,7 +71,7 @@ namespace WinBlur.App.Helpers
                 htmlScrollbarColor = scrollbarColor;
                 htmlStyleHeader = string.Format(@"
                     <head>
-                        <meta name=""viewport"" content=""initial-scale=1"" />
+                        <meta name=""viewport"" content=""initial-scale=1 minimum-scale=1"" />
                         <style type=""text/css"">
                             html {{
                                 background-color: #{0};

--- a/src/WinBlur.App/Helpers/DependencyPropertyHelper.cs
+++ b/src/WinBlur.App/Helpers/DependencyPropertyHelper.cs
@@ -41,6 +41,12 @@ namespace WinBlur.App.Helpers
         public static SolidColorBrush GetHtmlContentLinkColor(DependencyObject obj) { return (SolidColorBrush)obj.GetValue(HtmlContentLinkColorProperty); }
         public static void SetHtmlContentLinkColor(DependencyObject obj, SolidColorBrush value) { obj.SetValue(HtmlContentLinkColorProperty, value); }
 
+        public static readonly DependencyProperty HtmlContentScrollbarBackgroundColorProperty =
+            DependencyProperty.RegisterAttached("HtmlContentScrollbarBackgroundColor", typeof(SolidColorBrush), typeof(DependencyPropertyHelper), new PropertyMetadata(null));
+
+        public static SolidColorBrush GetHtmlContentScrollbarBackgroundColor(DependencyObject obj) { return (SolidColorBrush)obj.GetValue(HtmlContentScrollbarBackgroundColorProperty); }
+        public static void SetHtmlContentScrollbarBackgroundColor(DependencyObject obj, SolidColorBrush value) { obj.SetValue(HtmlContentScrollbarBackgroundColorProperty, value); }
+
         public static readonly DependencyProperty HtmlContentScrollbarColorProperty =
             DependencyProperty.RegisterAttached("HtmlContentScrollbarColor", typeof(SolidColorBrush), typeof(DependencyPropertyHelper), new PropertyMetadata(null));
 
@@ -51,30 +57,33 @@ namespace WinBlur.App.Helpers
         private static string htmlBackgroundColor;
         private static string htmlForegroundColor;
         private static string htmlLinkColor;
+        private static string htmlScrollbarBackgroundColor;
         private static string htmlScrollbarColor;
         private static string GetHtmlStyleHeader(DependencyObject obj)
         {
             string bgColor = GetHtmlContentBackground(obj).Color.ToString();
             string fgColor = GetHtmlContentForeground(obj).Color.ToString();
             string linkColor = GetHtmlContentLinkColor(obj).Color.ToString();
+            string scrollbarBackgroundColor = GetHtmlContentScrollbarBackgroundColor(obj).Color.ToString();
             string scrollbarColor = GetHtmlContentScrollbarColor(obj).Color.ToString();
 
             if (bgColor != htmlBackgroundColor ||
                 fgColor != htmlForegroundColor ||
                 linkColor != htmlLinkColor ||
+                scrollbarBackgroundColor != htmlScrollbarBackgroundColor ||
                 scrollbarColor != htmlScrollbarColor)
             {
                 // Style changed - update strings and return
                 htmlBackgroundColor = bgColor;
                 htmlForegroundColor = fgColor;
                 htmlLinkColor = linkColor;
+                htmlScrollbarBackgroundColor = scrollbarBackgroundColor;
                 htmlScrollbarColor = scrollbarColor;
                 htmlStyleHeader = string.Format(@"
                     <head>
                         <meta name=""viewport"" content=""initial-scale=1 minimum-scale=1"" />
                         <style type=""text/css"">
                             html {{
-                                background-color: #{0};
                                 color: #{1};
                                 font-family: ""Segoe UI Variable"", ""Segoe UI"", sans-serif;
                                 line-height: 175%;
@@ -110,18 +119,19 @@ namespace WinBlur.App.Helpers
                                 width: 10px;
                             }}
                             ::-webkit-scrollbar-track {{
-                                background: #{0};
+                                background: #{3};
                             }}
                             ::-webkit-scrollbar-thumb {{
-                                background: #{3};
+                                background: #{4};
                                 border-radius: 10px;
-                                border: 4px solid #{0};
+                                border: 4px solid #{3};
                             }}
                         </style>
                     </head>",
                     bgColor.Substring(3),
                     fgColor.Substring(3),
                     linkColor.Substring(3),
+                    scrollbarBackgroundColor.Substring(3),
                     scrollbarColor.Substring(3));
             }
             return htmlStyleHeader;

--- a/src/WinBlur.App/Model/Settings.cs
+++ b/src/WinBlur.App/Model/Settings.cs
@@ -19,7 +19,6 @@ namespace WinBlur.App.Model
         #region Properties
 
         // Theme Helpers
-        private ThemeListener themeListener = new ThemeListener();
         private UISettings uiSettings = new UISettings();
         private Color accentColor;
         private DispatcherQueue dispatcherQueue;
@@ -152,7 +151,6 @@ namespace WinBlur.App.Model
 
         public Settings()
         {
-            themeListener.ThemeChanged += ThemeListener_ThemeChanged;
             accentColor = uiSettings.GetColorValue(UIColorType.Accent);
             dispatcherQueue = DispatcherQueue.GetForCurrentThread();
             uiSettings.ColorValuesChanged += UISettings_ColorValuesChanged;
@@ -450,6 +448,7 @@ namespace WinBlur.App.Model
             Color newAccentColor = sender.GetColorValue(UIColorType.Accent);
             await dispatcherQueue.EnqueueAsync(() =>
             {
+                UpdateAppTheme();
                 if (accentColor != newAccentColor)
                 {
                     accentColor = newAccentColor;
@@ -458,25 +457,24 @@ namespace WinBlur.App.Model
             });
         }
 
-        private void ThemeListener_ThemeChanged(ThemeListener sender)
-        {
-            UpdateAppTheme();
-        }
-
         public void UpdateAppTheme()
         {
             if (App.Window.Content is FrameworkElement element)
-            { 
+            {
+                var oldTheme = element.RequestedTheme;
                 if (AppTheme2 == AppThemeMode.UseWindowsTheme)
                 {
-                    element.RequestedTheme = AppThemeToElementTheme(themeListener.CurrentTheme);
+                    element.RequestedTheme = AppThemeToElementTheme(Application.Current.RequestedTheme);
                 }
                 else
                 {
                     element.RequestedTheme = AppThemeToElementTheme((ApplicationTheme)AppTheme2);
                 }
 
-                ThemeChanged?.Invoke(this, EventArgs.Empty);
+                if (element.RequestedTheme != oldTheme)
+                {
+                    ThemeChanged?.Invoke(this, EventArgs.Empty);
+                }
             }
         }
 

--- a/src/WinBlur.App/View/ArticleFlipView.cs
+++ b/src/WinBlur.App/View/ArticleFlipView.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System.Linq;
+
+namespace WinBlur.App.View
+{
+    public class ArticleFlipView : FlipView
+    {
+        protected override void OnApplyTemplate()
+        {
+            base.OnApplyTemplate();
+            SelectionChanged += (s, e) => UpdateNavigationButtonsVisibility();
+
+            Button prev = GetTemplateChild("MyPreviousButtonHorizontal") as Button;
+            prev.Click += OnBack;
+            prev.Visibility = Visibility.Collapsed;
+
+            Button next = GetTemplateChild("MyNextButtonHorizontal") as Button;
+            next.Click += OnNext;
+            next.Visibility = Visibility.Collapsed;
+
+            UpdateNavigationButtonsVisibility();
+        }
+
+        private void OnBack(object sender, RoutedEventArgs e)
+        {
+            if (Items.Any())
+            {
+                SelectedIndex--;
+                UpdateNavigationButtonsVisibility();
+            }
+        }
+
+        private void OnNext(object sender, RoutedEventArgs e)
+        {
+            if (Items.Any())
+            {
+                SelectedIndex++;
+                UpdateNavigationButtonsVisibility();
+            }
+        }
+
+        private void UpdateNavigationButtonsVisibility()
+        {
+            Button prev = GetTemplateChild("MyPreviousButtonHorizontal") as Button;
+            Button next = GetTemplateChild("MyNextButtonHorizontal") as Button;
+
+            if (SelectedIndex < 1)
+                prev.Visibility = Visibility.Collapsed;
+            if (SelectedIndex == Items.Count - 1)
+                next.Visibility = Visibility.Collapsed;
+            if (Items.Count > 1 && SelectedIndex != Items.Count - 1)
+                next.Visibility = Visibility.Visible;
+            if (Items.Count > 1 && SelectedIndex > 0)
+                prev.Visibility = Visibility.Visible;
+        }
+    }
+}

--- a/src/WinBlur.App/View/Styles.xaml
+++ b/src/WinBlur.App/View/Styles.xaml
@@ -18,6 +18,7 @@
 
             <!-- Article content brushes -->
             <SolidColorBrush x:Key="ArticleContentHyperlinkBrush" Color="{StaticResource SystemAccentColorDark1}"/>
+            <SolidColorBrush x:Key="ArticleContentScrollbarBackgroundBrush" Color="#FCFCFC"/>
             <SolidColorBrush x:Key="ArticleContentScrollbarBrush" Color="#8A8A8A"/>
         </ResourceDictionary>
 
@@ -29,6 +30,7 @@
 
             <!-- Article content brushes -->
             <SolidColorBrush x:Key="ArticleContentHyperlinkBrush" Color="{StaticResource SystemAccentColorLight1}"/>
+            <SolidColorBrush x:Key="ArticleContentScrollbarBackgroundBrush" Color="#2C2C2C"/>
             <SolidColorBrush x:Key="ArticleContentScrollbarBrush" Color="#A1A1A1"/>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
@@ -265,7 +267,7 @@
     </Style>
 
     <Style x:Key="ArticleFlipViewStyle" TargetType="FlipView">
-        <Setter Property="Background" Value="{ThemeResource FlipViewBackground}" />
+        <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="TabNavigation" Value="Once" />
         <Setter Property="IsTabStop" Value="False" />

--- a/src/WinBlur.App/View/Styles.xaml
+++ b/src/WinBlur.App/View/Styles.xaml
@@ -264,6 +264,346 @@
         </Setter>
     </Style>
 
+    <Style x:Key="ArticleFlipViewStyle" TargetType="FlipView">
+        <Setter Property="Background" Value="{ThemeResource FlipViewBackground}" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="TabNavigation" Value="Once" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
+        <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="False" />
+        <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="False" />
+        <Setter Property="ScrollViewer.IsHorizontalScrollChainingEnabled" Value="True" />
+        <Setter Property="ScrollViewer.IsVerticalScrollChainingEnabled" Value="True" />
+        <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
+        <Setter Property="ScrollViewer.BringIntoViewOnFocusChange" Value="True" />
+        <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+        <Setter Property="ItemsPanel">
+            <Setter.Value>
+                <ItemsPanelTemplate>
+                    <VirtualizingStackPanel AreScrollSnapPointsRegular="True" Orientation="Horizontal" />
+                </ItemsPanelTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="FlipView">
+                    <Grid
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{TemplateBinding CornerRadius}">
+                        <Grid.Resources>
+                            <ControlTemplate x:Key="HorizontalNextTemplate" TargetType="Button">
+                                <Border x:Name="Root"
+                                    Background="{ThemeResource FlipViewNextPreviousButtonBackground}"
+                                    BorderThickness="{ThemeResource FlipViewButtonBorderThemeThickness}"
+                                    BorderBrush="{ThemeResource FlipViewNextPreviousButtonBorderBrush}"
+                                    CornerRadius="{TemplateBinding CornerRadius}">
+                                    <VisualStateManager.VisualStateGroups>
+                                        <VisualStateGroup x:Name="CommonStates">
+                                            <VisualState x:Name="Normal" />
+                                            <VisualState x:Name="PointerOver">
+                                                <Storyboard>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="Background">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousButtonBackgroundPointerOver}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="BorderBrush">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousButtonBorderBrushPointerOver}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="Foreground">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousArrowForegroundPointerOver}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                </Storyboard>
+                                            </VisualState>
+                                            <VisualState x:Name="Pressed">
+                                                <Storyboard>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="Background">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousButtonBackgroundPressed}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="BorderBrush">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousButtonBorderBrushPressed}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="Foreground">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousArrowForegroundPressed}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)" RepeatBehavior="Forever">
+                                                        <DiscreteDoubleKeyFrame KeyTime="0:0:0.016" Value="{ThemeResource FlipViewButtonScalePressed}"/>
+                                                        <DiscreteDoubleKeyFrame KeyTime="0:0:30" Value="{ThemeResource FlipViewButtonScalePressed}"/>
+                                                    </DoubleAnimationUsingKeyFrames>
+                                                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)" RepeatBehavior="Forever">
+                                                        <DiscreteDoubleKeyFrame KeyTime="0:0:0.016" Value="{ThemeResource FlipViewButtonScalePressed}"/>
+                                                        <DiscreteDoubleKeyFrame KeyTime="0:0:30" Value="{ThemeResource FlipViewButtonScalePressed}"/>
+                                                    </DoubleAnimationUsingKeyFrames>
+                                                </Storyboard>
+                                            </VisualState>
+                                        </VisualStateGroup>
+                                    </VisualStateManager.VisualStateGroups>
+                                    <FontIcon x:Name="Arrow"
+                                        FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                        FontSize="{ThemeResource FlipViewButtonFontSize}"
+                                        Foreground="{ThemeResource FlipViewNextPreviousArrowForeground}"
+                                        Glyph="&#xEDDA;"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        MirroredWhenRightToLeft="True"
+                                        UseLayoutRounding="False"
+                                        RenderTransformOrigin="0.5, 0.5">
+                                        <FontIcon.RenderTransform>
+                                            <ScaleTransform x:Name="ScaleTransform" ScaleY="1" ScaleX="1" />
+                                        </FontIcon.RenderTransform>
+                                    </FontIcon>
+                                </Border>
+                            </ControlTemplate>
+                            <ControlTemplate x:Key="HorizontalPreviousTemplate" TargetType="Button">
+                                <Border x:Name="Root"
+                                    Background="{ThemeResource FlipViewNextPreviousButtonBackground}"
+                                    BorderThickness="{ThemeResource FlipViewButtonBorderThemeThickness}"
+                                    BorderBrush="{ThemeResource FlipViewNextPreviousButtonBorderBrush}"
+                                    CornerRadius="{TemplateBinding CornerRadius}">
+                                    <VisualStateManager.VisualStateGroups>
+                                        <VisualStateGroup x:Name="CommonStates">
+                                            <VisualState x:Name="Normal" />
+                                            <VisualState x:Name="PointerOver">
+                                                <Storyboard>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="Background">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousButtonBackgroundPointerOver}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="BorderBrush">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousButtonBorderBrushPointerOver}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="Foreground">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousArrowForegroundPointerOver}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                </Storyboard>
+                                            </VisualState>
+                                            <VisualState x:Name="Pressed">
+                                                <Storyboard>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="Background">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousButtonBackgroundPressed}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="BorderBrush">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousButtonBorderBrushPressed}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="Foreground">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousArrowForegroundPressed}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)" RepeatBehavior="Forever">
+                                                        <DiscreteDoubleKeyFrame KeyTime="0:0:0.016" Value="{ThemeResource FlipViewButtonScalePressed}"/>
+                                                        <DiscreteDoubleKeyFrame KeyTime="0:0:30" Value="{ThemeResource FlipViewButtonScalePressed}"/>
+                                                    </DoubleAnimationUsingKeyFrames>
+                                                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)" RepeatBehavior="Forever">
+                                                        <DiscreteDoubleKeyFrame KeyTime="0:0:0.016" Value="{ThemeResource FlipViewButtonScalePressed}"/>
+                                                        <DiscreteDoubleKeyFrame KeyTime="0:0:30" Value="{ThemeResource FlipViewButtonScalePressed}"/>
+                                                    </DoubleAnimationUsingKeyFrames>
+                                                </Storyboard>
+                                            </VisualState>
+                                        </VisualStateGroup>
+                                    </VisualStateManager.VisualStateGroups>
+                                    <FontIcon x:Name="Arrow"
+                                        FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                        FontSize="{ThemeResource FlipViewButtonFontSize}"
+                                        Foreground="{ThemeResource FlipViewNextPreviousArrowForeground}"
+                                        Glyph="&#xEDD9;"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        MirroredWhenRightToLeft="True"
+                                        UseLayoutRounding="False"
+                                        RenderTransformOrigin="0.5, 0.5">
+                                        <FontIcon.RenderTransform>
+                                            <ScaleTransform x:Name="ScaleTransform" ScaleY="1" ScaleX="1" />
+                                        </FontIcon.RenderTransform>
+                                    </FontIcon>
+                                </Border>
+                            </ControlTemplate>
+                            <ControlTemplate x:Key="VerticalNextTemplate" TargetType="Button">
+                                <Border x:Name="Root"
+                                        Background="{ThemeResource FlipViewNextPreviousButtonBackground}"
+                                        BorderThickness="{ThemeResource FlipViewButtonBorderThemeThickness}"
+                                        BorderBrush="{ThemeResource FlipViewNextPreviousButtonBorderBrush}"
+                                        CornerRadius="{TemplateBinding CornerRadius}">
+                                    <VisualStateManager.VisualStateGroups>
+                                        <VisualStateGroup x:Name="CommonStates">
+                                            <VisualState x:Name="Normal" />
+                                            <VisualState x:Name="PointerOver">
+                                                <Storyboard>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="Background">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousButtonBackgroundPointerOver}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="BorderBrush">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousButtonBorderBrushPointerOver}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="Foreground">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousArrowForegroundPointerOver}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                </Storyboard>
+                                            </VisualState>
+                                            <VisualState x:Name="Pressed">
+                                                <Storyboard>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="Background">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousButtonBackgroundPressed}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="BorderBrush">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousButtonBorderBrushPressed}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="Foreground">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousArrowForegroundPressed}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)" RepeatBehavior="Forever">
+                                                        <DiscreteDoubleKeyFrame KeyTime="0:0:0.016" Value="{ThemeResource FlipViewButtonScalePressed}"/>
+                                                        <DiscreteDoubleKeyFrame KeyTime="0:0:30" Value="{ThemeResource FlipViewButtonScalePressed}"/>
+                                                    </DoubleAnimationUsingKeyFrames>
+                                                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)" RepeatBehavior="Forever">
+                                                        <DiscreteDoubleKeyFrame KeyTime="0:0:0.016" Value="{ThemeResource FlipViewButtonScalePressed}"/>
+                                                        <DiscreteDoubleKeyFrame KeyTime="0:0:30" Value="{ThemeResource FlipViewButtonScalePressed}"/>
+                                                    </DoubleAnimationUsingKeyFrames>
+                                                </Storyboard>
+                                            </VisualState>
+                                        </VisualStateGroup>
+                                    </VisualStateManager.VisualStateGroups>
+                                    <FontIcon x:Name="Arrow"
+                                        FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                        FontSize="{ThemeResource FlipViewButtonFontSize}"
+                                        Foreground="{ThemeResource FlipViewNextPreviousArrowForeground}"
+                                        Glyph="&#xEDDC;"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        UseLayoutRounding="False"
+                                        RenderTransformOrigin="0.5, 0.5">
+                                        <FontIcon.RenderTransform>
+                                            <ScaleTransform x:Name="ScaleTransform" ScaleY="1" ScaleX="1" />
+                                        </FontIcon.RenderTransform>
+                                    </FontIcon>
+                                </Border>
+                            </ControlTemplate>
+                            <ControlTemplate x:Key="VerticalPreviousTemplate" TargetType="Button">
+                                <Border x:Name="Root"
+                                    Background="{ThemeResource FlipViewNextPreviousButtonBackground}"
+                                    BorderThickness="{ThemeResource FlipViewButtonBorderThemeThickness}"
+                                    BorderBrush="{ThemeResource FlipViewNextPreviousButtonBorderBrush}"
+                                    CornerRadius="{TemplateBinding CornerRadius}">
+                                    <VisualStateManager.VisualStateGroups>
+                                        <VisualStateGroup x:Name="CommonStates">
+                                            <VisualState x:Name="Normal" />
+                                            <VisualState x:Name="PointerOver">
+                                                <Storyboard>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="Background">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousButtonBackgroundPointerOver}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="BorderBrush">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousButtonBorderBrushPointerOver}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="Foreground">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousArrowForegroundPointerOver}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                </Storyboard>
+                                            </VisualState>
+                                            <VisualState x:Name="Pressed">
+                                                <Storyboard>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="Background">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousButtonBackgroundPressed}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="BorderBrush">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousButtonBorderBrushPressed}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="Foreground">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource FlipViewNextPreviousArrowForegroundPressed}" />
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)" RepeatBehavior="Forever">
+                                                        <DiscreteDoubleKeyFrame KeyTime="0:0:0.016" Value="{ThemeResource FlipViewButtonScalePressed}"/>
+                                                        <DiscreteDoubleKeyFrame KeyTime="0:0:30" Value="{ThemeResource FlipViewButtonScalePressed}"/>
+                                                    </DoubleAnimationUsingKeyFrames>
+                                                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)" RepeatBehavior="Forever">
+                                                        <DiscreteDoubleKeyFrame KeyTime="0:0:0.016" Value="{ThemeResource FlipViewButtonScalePressed}"/>
+                                                        <DiscreteDoubleKeyFrame KeyTime="0:0:30" Value="{ThemeResource FlipViewButtonScalePressed}"/>
+                                                    </DoubleAnimationUsingKeyFrames>
+                                                </Storyboard>
+                                            </VisualState>
+                                        </VisualStateGroup>
+                                    </VisualStateManager.VisualStateGroups>
+                                    <FontIcon x:Name="Arrow"
+                                        FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                        FontSize="{ThemeResource FlipViewButtonFontSize}"
+                                        Foreground="{ThemeResource FlipViewNextPreviousArrowForeground}"
+                                        Glyph="&#xEDDB;"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        UseLayoutRounding="False"
+                                        RenderTransformOrigin="0.5, 0.5">
+                                        <FontIcon.RenderTransform>
+                                            <ScaleTransform x:Name="ScaleTransform" ScaleY="1" ScaleX="1" />
+                                        </FontIcon.RenderTransform>
+                                    </FontIcon>
+                                </Border>
+                            </ControlTemplate>
+                        </Grid.Resources>
+                        <ScrollViewer x:Name="ScrollingHost"
+                            VerticalSnapPointsType="MandatorySingle"
+                            HorizontalSnapPointsType="MandatorySingle"
+                            HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+                            HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                            VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+                            VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                            IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+                            IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+                            IsHorizontalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsHorizontalScrollChainingEnabled}"
+                            IsVerticalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsVerticalScrollChainingEnabled}"
+                            IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                            BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
+                            Padding="{TemplateBinding Padding}"
+                            ZoomMode="Disabled"
+                            TabNavigation="{TemplateBinding TabNavigation}"
+                            IsTabStop="False"
+                            AutomationProperties.AccessibilityView="Raw">
+                            <ItemsPresenter />
+                        </ScrollViewer>
+                        <Button x:Name="MyPreviousButtonHorizontal"
+                            Template="{StaticResource HorizontalPreviousTemplate}"
+                            Width="16"
+                            Height="38"
+                            Margin="1"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            IsTabStop="False"
+                            UseSystemFocusVisuals="False"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center" />
+                        <Button x:Name="MyNextButtonHorizontal"
+                            Template="{StaticResource HorizontalNextTemplate}"
+                            Width="16"
+                            Height="38"
+                            Margin="1"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            IsTabStop="False"
+                            UseSystemFocusVisuals="False"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Center" />
+                        <Button x:Name="PreviousButtonVertical"
+                            Template="{StaticResource VerticalPreviousTemplate}"
+                            Width="38"
+                            Height="16"
+                            Margin="1"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            IsTabStop="False"
+                            UseSystemFocusVisuals="False"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Top" />
+                        <Button x:Name="NextButtonVertical"
+                            Template="{StaticResource VerticalNextTemplate}"
+                            Width="38"
+                            Height="16"
+                            Margin="1"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            IsTabStop="False"
+                            UseSystemFocusVisuals="False"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Bottom" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <!-- Converters -->
     <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
     <converters:BoolToVisibilityConverter x:Key="BoolToCollapsedConverter" TrueValue="Collapsed" FalseValue="Visible"/>

--- a/src/WinBlur.App/WinBlur.App.csproj
+++ b/src/WinBlur.App/WinBlur.App.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" Version="0.0.18" />
     <PackageReference Include="CommunityToolkit.WinUI.UI" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230217.4" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.230913002" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <Manifest Include="$(ApplicationManifest)" />

--- a/src/WinBlur.BackgroundTasks/WinBlur.BackgroundTasks.csproj
+++ b/src/WinBlur.BackgroundTasks/WinBlur.BackgroundTasks.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230217.4" />
+      <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.230913002" />
       <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/src/WinBlur.Shared/WinBlur.Shared.csproj
+++ b/src/WinBlur.Shared/WinBlur.Shared.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230217.4" />
+      <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.230913002" />
       <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>


### PR DESCRIPTION
- Configure webview2s to disable unneeded functionality to improve security and remove unintended behaviors
- Move to WinAppSDK 1.4 to fix some bugs
- Override FlipView to always show prev/next buttons to workaround [issue where webview doesn't support scroll chaining](https://github.com/microsoft/microsoft-ui-xaml/issues/4596) . This allows touch users to navigate.
- Make webview background transparent so Mica shows through!
- Remove use of CommunityToolkit ThemeListener since it's broken in WinUI 3. Fix theme change events using UISettings event